### PR TITLE
Fix regex and currency display

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -26,7 +26,7 @@ class CommissionRecord(db.Model):
     commission_type = db.Column(db.String(50), nullable=True)
 
 def extract_phone_number(account_str):
-    match = re.match(r"^(\\d{10})", account_str)
+    match = re.match(r"^(\d{10})", account_str)
     return match.group(1) if match else None
 
 @app.route('/summary', methods=['GET'])

--- a/frontend/src/CommissionDashboard.jsx
+++ b/frontend/src/CommissionDashboard.jsx
@@ -30,7 +30,7 @@ export default function CommissionDashboard() {
         <Card>
           <CardContent className="p-4">
             <h2 className="text-lg font-semibold">Total Commission</h2>
-            <p className="text-xl font-bold text-green-600">${summary.total_commission}</p>
+            <p className="text-xl font-bold text-green-600">{'$' + summary.total_commission}</p>
           </CardContent>
         </Card>
         <Card>
@@ -42,7 +42,7 @@ export default function CommissionDashboard() {
         <Card>
           <CardContent className="p-4">
             <h2 className="text-lg font-semibold">Avg. Commission / Line</h2>
-            <p className="text-xl font-bold">${summary.average_commission_per_line}</p>
+            <p className="text-xl font-bold">{'$' + summary.average_commission_per_line}</p>
           </CardContent>
         </Card>
       </div>
@@ -76,7 +76,7 @@ export default function CommissionDashboard() {
                   <TableCell>{line.carrier}</TableCell>
                   <TableCell>{line.activation_date}</TableCell>
                   <TableCell>{line.line_description}</TableCell>
-                  <TableCell>${line.total_commission}</TableCell>
+                  <TableCell>{'$' + line.total_commission}</TableCell>
                 </TableRow>
               ))}
             </TableBody>


### PR DESCRIPTION
## Summary
- correct phone number regex in Flask backend
- display currency values properly in Commission Dashboard

## Testing
- `python3 -m py_compile backend/app.py`

------
https://chatgpt.com/codex/tasks/task_b_684f97517a2083249e29aecd00074919