### PR TITLE
Add GitHub Pages placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Commission Tracker
+
+This repository contains an early prototype of a commission tracking
+tool with a Flask backend and a React-based frontend.
+
+A minimal static page is provided under the `docs/` directory so the
+project can be served with GitHub Pages.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,5 @@
+# GitHub Pages
+
+This directory contains the static site used for GitHub Pages deployment.
+
+Open `index.html` to view the placeholder page while development continues.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Commission Tracker</title>
+  <style>
+    body { font-family: Arial, sans-serif; padding: 2rem; }
+    h1 { color: #333; }
+  </style>
+</head>
+<body>
+  <h1>Commission Tracker</h1>
+  <p>This project contains a Flask backend and a React frontend. The static
+     version of the site is hosted via GitHub Pages.</p>
+  <p>The interactive dashboard is still under development.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create docs directory with placeholder index.html
- add docs/README to explain GitHub Pages usage
- add project README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684f98eef00883248c6d90beed019ad7